### PR TITLE
Version 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function setBackground(location) {
     'options',
     workspace('desktopImageOptionsForScreen', mainScreen)('mutableCopy'),
     'error',
-    ffi.NULL_POINTER
+    $.alloc($.NSError).ref()
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -21,13 +21,13 @@ function setBackground(location) {
 
   return !!workspace(
     'setDesktopImageURL',
-    $.NSURL('URLWithString', $('file://localhost/' + path.resolve(location))),
+      $.NSURL('URLWithString', $('file://localhost/' + path.resolve(location))),
     'forScreen',
-    mainScreen,
+      mainScreen,
     'options',
-    workspace('desktopImageOptionsForScreen', mainScreen)('mutableCopy'),
+      workspace('desktopImageOptionsForScreen', mainScreen)('mutableCopy'),
     'error',
-    $.alloc($.NSError).ref()
+      $.alloc($.NSError).ref()
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -1,33 +1,34 @@
-var $ = require('NodObjC')
-  , ffi = require('NodObjC/node_modules/node-ffi')
-  , path = require('path')
+var $ = require('nodobjc'),
+  ffi = require('ffi'),
+  path = require('path');
 
 module.exports = {
-    get: getBackground
-  , set: setBackground
-}
+  get: getBackground,
+  set: setBackground
+};
 
 function getBackground() {
-  return String($.NSWorkspace('sharedWorkspace')(
-      'desktopImageURLForScreen'
-    , $.NSScreen('mainScreen')
-  )).replace(/^file\:\/\/localhost/i, '')
+  return String(
+    $.NSWorkspace('sharedWorkspace')(
+      'desktopImageURLForScreen', $.NSScreen('mainScreen')
+    )
+  ).replace(/^file\:\/\/localhost/i, '');
 }
 
 function setBackground(location) {
-  var workspace = $.NSWorkspace('sharedWorkspace')
-    , mainScreen = $.NSScreen('mainScreen')
+  var workspace = $.NSWorkspace('sharedWorkspace'),
+    mainScreen = $.NSScreen('mainScreen');
 
   return !!workspace(
-      'setDesktopImageURL'
-    , $.NSURL('URLWithString', $('file://localhost/' + path.resolve(location)))
-    , 'forScreen'
-    , mainScreen
-    , 'options'
-    , workspace('desktopImageOptionsForScreen', mainScreen)('mutableCopy')
-    , 'error'
-    , ffi.Pointer.NULL
-  )
+    'setDesktopImageURL',
+    $.NSURL('URLWithString', $('file://localhost/' + path.resolve(location))),
+    'forScreen',
+    mainScreen,
+    'options',
+    workspace('desktopImageOptionsForScreen', mainScreen)('mutableCopy'),
+    'error',
+    ffi.NULL_POINTER
+  );
 }
 
-$.framework('cocoa')
+$.framework('cocoa');

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "osx-background",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Get and set your OSX desktop background image programmatically",
   "main": "index.js",
   "dependencies": {
-    "NodObjC": "~0.0.15"
+    "ffi": "1.3.x",
+    "nodobjc": "2.0.x"
   },
-  "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- [x] Update & fix syntax
- [x] Update dependencies
- [ ] Make it work

With nodobjc being outdated the whole app breaks. Currently on my fork I've updated `nodobjc` and also made `ffi` an actual dependency. I'm currently attempting to fix the `set()` functionality. tbh I don't know anything about Obj-C, but I've been looking at `NSWorkSpace` to see if I can find the solution. I've created a script that will set the background but this is the error I receive: 

```
/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/lib/class.js:193
      else throw e;
                 ^
TypeError: error setting argument 5 - writePointer: Buffer instance expected as third argument
    at TypeError (native)
    at Object.writePointer (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/node_modules/ref/lib/ref.js:740:11)
    at Object.set (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/node_modules/ref/lib/ref.js:482:13)
    at Object.alloc (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/node_modules/ref/lib/ref.js:514:13)
    at ForeignFunction.proxy (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/node_modules/ffi/lib/_foreign_function.js:50:22)
    at unwrapper (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/lib/core.js:300:31)
    at ID.module.exports.Class.msgSend (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/lib/class.js:189:34)
    at rtn (/Users/henrysnopek/projects/osx-background/node_modules/nodobjc/lib/core.js:374:47)
    at Object.setBackground [as set] (/Users/henrysnopek/projects/osx-background/index.js:22:12)
    at Object.<anonymous> (/Users/henrysnopek/projects/osx-background/test/test.js:4:12)
```

Could you lend me some assistance?
